### PR TITLE
Fix a word mistake

### DIFF
--- a/3.0/controller.md
+++ b/3.0/controller.md
@@ -393,11 +393,11 @@ module.exports = class extends think.Controller {
 
 #### controller.redirect(url)
 
-页面跳转，等用于 [ctx.redirect](/doc/3.0/context.html#toc-3e0)。
+页面跳转，等同于 [ctx.redirect](/doc/3.0/context.html#toc-3e0)。
 
 #### controller.jsonp(data, callback)
 
-输出 jsonp 格式内容，等用于 [ctx.jsonp](/doc/3.0/context.html#toc-45f)。
+输出 jsonp 格式内容，等同于 [ctx.jsonp](/doc/3.0/context.html#toc-45f)。
 
 #### controller.json(data)
 


### PR DESCRIPTION
3.0文档Controller章节有两处介绍 controller.redirect(url) 和 controller.jsonp(data, callback)，解释文字应为【等同于 ctx.xxx】，而非【等用于 ctx.xxx】