### PR TITLE
解决按照文档配置报错的问题

### DIFF
--- a/3.0/websocket.md
+++ b/3.0/websocket.md
@@ -15,6 +15,12 @@ module.exports = {
 };
 ```
 
+与此同时，ThinkJs将`websocket`封装为`think-websocket`,但是需要在项目目录下执行
+```sh
+$ npm install -s think-websocket
+```
+来安装模块
+
 ### 配置 WebSocket
 
 WebSocket 是以 `extend` 的形式集成到 ThinkJS 的，首先要配置 `src/config/extend.js`:

--- a/3.0/websocket.md
+++ b/3.0/websocket.md
@@ -15,7 +15,7 @@ module.exports = {
 };
 ```
 
-与此同时，ThinkJs将`websocket`封装为`think-websocket`,但是需要在项目目录下执行
+与此同时，ThinkJS将`websocket`封装为`think-websocket`,但是需要在项目目录下执行
 ```sh
 $ npm install -s think-websocket
 ```


### PR DESCRIPTION
think-websocket模块在按照文档配置后需要手动安装，感觉需要说明。