### PR TITLE
Update create_project.md

### DIFF
--- a/3.0/create_project.md
+++ b/3.0/create_project.md
@@ -16,7 +16,7 @@ $ npm install -g think-cli
 ### 卸载旧版本命令
 
 ```sh
-$ npm uninstall -g thinkjs
+$ npm uninstall -g think-cli
 ```
 
 ### 创建项目


### PR DESCRIPTION
今天准备卸载版本2.2.8再装3.0 的时候用以上命令(npm uninstall -g thinkjs)全局卸载没有反应，改成npm uninstall -g think-cli 卸载成功。所全局卸载命令是 : npm uninstall -g think-cli